### PR TITLE
Csl background color

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/ColorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/ColorManager.cs
@@ -7,6 +7,8 @@ namespace TabloidCLI.UserInterfaceManagers
     public class ColorManager : IUserInterfaceManager
     {
         readonly IUserInterfaceManager _parentUI;
+        ConsoleColor bgColor = new ConsoleColor();
+        ConsoleColor fgColor = new ConsoleColor();
 
         public ColorManager(IUserInterfaceManager parentUI)
         {
@@ -16,35 +18,47 @@ namespace TabloidCLI.UserInterfaceManagers
         public IUserInterfaceManager Execute()
         {
             Console.WriteLine("Background Color Menu");
-            Console.WriteLine(" 1) ");
-            Console.WriteLine(" 2) ");
-            Console.WriteLine(" 3) ");
-            Console.WriteLine(" 4) ");
+            Console.WriteLine(" 1) White");
+            Console.WriteLine(" 2) Blue");
+            Console.WriteLine(" 3) Red");
+            Console.WriteLine(" 4) Green");
             Console.WriteLine(" 5) Reset to Default");
-            Console.WriteLine(" 0) Go Back without making changes");
+            Console.WriteLine(" 0) Go Back");
 
             Console.Write("> ");
             string choice = Console.ReadLine();
             switch (choice)
             { 
                 case "1":
+                    bgColor = ConsoleColor.White;
+                    fgColor = ConsoleColor.Black;
                     Color();
                     return this;
                 case "2":
+                    bgColor = ConsoleColor.DarkBlue;
+                    fgColor = ConsoleColor.White;
                     Color();
                     return this;
                 case "3":
+                    bgColor = ConsoleColor.DarkRed;
+                    fgColor = ConsoleColor.White;
                     Color();
                     return this;
                 case "4":
+                    bgColor = ConsoleColor.DarkGreen;
+                    fgColor = ConsoleColor.White;
                     Color();
                     return this;
                 case "5":
-                    Color();
+                    Console.ResetColor();
+                    Console.Clear();
+                    Console.WriteLine("");
                     return this;
                 case "0":
+                    Console.Clear();
                     return _parentUI;
                 default:
+                    Console.Clear();
                     Console.WriteLine("Invalid Selection");
                     return this;
             }
@@ -53,9 +67,8 @@ namespace TabloidCLI.UserInterfaceManagers
         private void Color()
         {
 
-
-            Console.ForegroundColor = ConsoleColor.Black;
-            Console.BackgroundColor = ConsoleColor.White;
+            Console.BackgroundColor = bgColor;
+            Console.ForegroundColor = fgColor;
 
             Console.Clear();
 

--- a/TabloidCLI/UserInterfaceManagers/ColorManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/ColorManager.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TabloidCLI.UserInterfaceManagers
+{
+    public class ColorManager : IUserInterfaceManager
+    {
+        readonly IUserInterfaceManager _parentUI;
+
+        public ColorManager(IUserInterfaceManager parentUI)
+        {
+            _parentUI = parentUI;
+        }
+
+        public IUserInterfaceManager Execute()
+        {
+            Console.WriteLine("Background Color Menu");
+            Console.WriteLine(" 1) ");
+            Console.WriteLine(" 2) ");
+            Console.WriteLine(" 3) ");
+            Console.WriteLine(" 4) ");
+            Console.WriteLine(" 5) Reset to Default");
+            Console.WriteLine(" 0) Go Back without making changes");
+
+            Console.Write("> ");
+            string choice = Console.ReadLine();
+            switch (choice)
+            { 
+                case "1":
+                    Color();
+                    return this;
+                case "2":
+                    Color();
+                    return this;
+                case "3":
+                    Color();
+                    return this;
+                case "4":
+                    Color();
+                    return this;
+                case "5":
+                    Color();
+                    return this;
+                case "0":
+                    return _parentUI;
+                default:
+                    Console.WriteLine("Invalid Selection");
+                    return this;
+            }
+        }
+
+        private void Color()
+        {
+
+
+            Console.ForegroundColor = ConsoleColor.Black;
+            Console.BackgroundColor = ConsoleColor.White;
+
+            Console.Clear();
+
+            // this is just to get the color to show.
+            Console.WriteLine("");
+            
+        }
+    }
+}

--- a/TabloidCLI/UserInterfaceManagers/MainMenuManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/MainMenuManager.cs
@@ -34,16 +34,16 @@ namespace TabloidCLI.UserInterfaceManagers
             string choice = Console.ReadLine();
             switch (choice)
             {
-                case "1": return new JournalManager(this, CONNECTION_STRING);
-                case "2": return new BlogManager(this, CONNECTION_STRING);
-                case "3": return new AuthorManager(this, CONNECTION_STRING);
-                case "4": return new PostManager(this, CONNECTION_STRING);
-                case "5": return new TagManager(this, CONNECTION_STRING);
-                case "6": return new SearchManager(this, CONNECTION_STRING);
+                case "1": Console.Clear(); return new JournalManager(this, CONNECTION_STRING);
+                case "2": Console.Clear(); return new BlogManager(this, CONNECTION_STRING);
+                case "3": Console.Clear(); return new AuthorManager(this, CONNECTION_STRING);
+                case "4": Console.Clear(); return new PostManager(this, CONNECTION_STRING);
+                case "5": Console.Clear(); return new TagManager(this, CONNECTION_STRING);
+                case "6": Console.Clear(); return new SearchManager(this, CONNECTION_STRING);
                 case "0":
                     Console.WriteLine("Good bye");
                     return null;
-                case "*": return new ColorManager(this);
+                case "*": Console.Clear(); return new ColorManager(this);
                 default:
                     Console.WriteLine("Invalid Selection");
                     return this;

--- a/TabloidCLI/UserInterfaceManagers/MainMenuManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/MainMenuManager.cs
@@ -27,7 +27,7 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine(" 4) Post Management");
             Console.WriteLine(" 5) Tag Management");
             Console.WriteLine(" 6) Search by Tag");
-            Console.WriteLine(" *) Color Themes");
+            Console.WriteLine(" 7) Color Themes");
             Console.WriteLine(" 0) Exit");
 
             Console.Write("> ");
@@ -43,7 +43,7 @@ namespace TabloidCLI.UserInterfaceManagers
                 case "0":
                     Console.WriteLine("Good bye");
                     return null;
-                case "*": Console.Clear(); return new ColorManager(this);
+                case "7": Console.Clear(); return new ColorManager(this);
                 default:
                     Console.WriteLine("Invalid Selection");
                     return this;

--- a/TabloidCLI/UserInterfaceManagers/MainMenuManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/MainMenuManager.cs
@@ -27,6 +27,7 @@ namespace TabloidCLI.UserInterfaceManagers
             Console.WriteLine(" 4) Post Management");
             Console.WriteLine(" 5) Tag Management");
             Console.WriteLine(" 6) Search by Tag");
+            Console.WriteLine(" *) Color Themes");
             Console.WriteLine(" 0) Exit");
 
             Console.Write("> ");
@@ -42,6 +43,7 @@ namespace TabloidCLI.UserInterfaceManagers
                 case "0":
                     Console.WriteLine("Good bye");
                     return null;
+                case "*": return new ColorManager(this);
                 default:
                     Console.WriteLine("Invalid Selection");
                     return this;


### PR DESCRIPTION
## Added color Manager 
options listed for different colors
switch statement used to choose the color based on the number selected.

## Added menu option to go to Color themes menu
MainMenuManager has a new case statement to open the ColorManager.

## Test

1. go to option 7) color themes
2. cycle through the background colors given
5. Select 0) Go Back
6. Color choice should remain.
7. Test 5) Reset to Default
7. Test a couple times to make sure the color remains when leaving the menu.